### PR TITLE
Fix broker connection status color

### DIFF
--- a/src/services/broker_service.py
+++ b/src/services/broker_service.py
@@ -170,6 +170,7 @@ class BrokerService:
             is_expired = self.is_token_expired(config.access_token)
             
             # Return data dictionary instead of SQLAlchemy object
+            is_connected = config.is_connected and not is_expired
             return {
                 'id': config.id,
                 'user_id': config.user_id,
@@ -182,10 +183,10 @@ class BrokerService:
                 'redirect_url': config.redirect_url,
                 'app_type': config.app_type,
                 'is_active': config.is_active,
-                'is_connected': config.is_connected and not is_expired,  # Mark as disconnected if token expired
+                'is_connected': is_connected,
                 'is_token_expired': is_expired,
                 'last_connection_test': config.last_connection_test,
-                'connection_status': 'expired' if is_expired else config.connection_status,
+                'connection_status': 'expired' if is_expired else ('connected' if is_connected else 'disconnected'),
                 'error_message': config.error_message,
                 'created_at': config.created_at,
                 'updated_at': config.updated_at


### PR DESCRIPTION
The broker connection status was showing a red color with a "connected" message, which is contradictory. This was happening on both the broker page and the system status in the settings page.

The issue was caused by an inconsistent logic in the `get_broker_config` method of the `BrokerService`. The `is_connected` field was being calculated based on the token expiration, but the `connection_status` field was being read directly from the database, which could be stale.

This commit fixes the logic to ensure that the `connection_status` is derived from the calculated `is_connected` value, which makes the status consistent across the UI.