### PR TITLE
feat: Replace Redis with Dragonfly

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,12 +16,12 @@ LOGS_DIR = DATA_DIR / "logs"
 POSTGRES_URL = os.environ.get('POSTGRES_URL', 'postgresql://postgres:password@localhost/stockexperiment')
 DATABASE_URL = os.environ.get('DATABASE_URL', POSTGRES_URL)
 
-# Redis configuration
-REDIS_URL = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
-REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
-REDIS_PORT = int(os.environ.get('REDIS_PORT', '6379'))
-REDIS_DB = int(os.environ.get('REDIS_DB', '0'))
-REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD', None)
+# Dragonfly configuration
+DRAGONFLY_URL = os.environ.get('DRAGONFLY_URL', 'redis://localhost:6379/0')
+DRAGONFLY_HOST = os.environ.get('DRAGONFLY_HOST', 'localhost')
+DRAGONFLY_PORT = int(os.environ.get('DRAGONFLY_PORT', '6379'))
+DRAGONFLY_DB = int(os.environ.get('DRAGONFLY_DB', '0'))
+DRAGONFLY_PASSWORD = os.environ.get('DRAGONFLY_PASSWORD', None)
 
 # Email configuration
 SMTP_SERVER = os.environ.get('SMTP_SERVER', 'smtp.gmail.com')

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,11 +6,11 @@ services:
     depends_on:
       database:
         condition: service_healthy
-      redis:
+      dragonfly:
         condition: service_healthy
     environment:
       - DATABASE_URL=postgresql://trader:trader_password@database:5432/trading_system
-      - REDIS_URL=redis://redis:6379/0
+      - DRAGONFLY_URL=redis://dragonfly:6379/0
       - FLASK_ENV=development
       - FLASK_DEBUG=1
       - PYTHONPATH=/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,11 +28,11 @@ services:
     depends_on:
       database:
         condition: service_healthy
-      redis:
+      dragonfly:
         condition: service_healthy
     environment:
       - DATABASE_URL=postgresql://trader:trader_password@database:5432/trading_system
-      - REDIS_URL=redis://redis:6379/0
+      - DRAGONFLY_URL=redis://dragonfly:6379/0
       - FLASK_ENV=production
       - PYTHONPATH=/app
       - FYERS_CLIENT_ID=${FYERS_CLIENT_ID:-your_client_id}
@@ -46,17 +46,17 @@ services:
       - trading_network
     command: python run.py --multi-user
 
-  # Redis for caching and session management
-  redis:
-    image: redis:7-alpine
-    container_name: trading_system_redis
+  # Dragonfly for caching and session management
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly
+    container_name: trading_system_dragonfly
     ports:
       - "6379:6379"
     restart: unless-stopped
     networks:
       - trading_network
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-h", "localhost", "-p", "6379", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/src/services/cache_service.py
+++ b/src/services/cache_service.py
@@ -1,5 +1,5 @@
 """
-Cache Service - Redis-based caching for tokens, API responses, and session data
+Cache Service - Dragonfly-based caching for tokens, API responses, and session data
 """
 import json
 import logging
@@ -11,32 +11,32 @@ import os
 logger = logging.getLogger(__name__)
 
 class CacheService:
-    """Redis-based cache service for the trading system."""
+    """Dragonfly-based cache service for the trading system."""
     
-    def __init__(self, redis_url: str = None):
+    def __init__(self, dragonfly_url: str = None):
         """
-        Initialize Redis cache service.
+        Initialize Dragonfly cache service.
         
         Args:
-            redis_url (str, optional): Redis connection URL
+            dragonfly_url (str, optional): Dragonfly connection URL
         """
-        self.redis_url = redis_url or os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
+        self.dragonfly_url = dragonfly_url or os.environ.get('DRAGONFLY_URL', 'redis://localhost:6379/0')
         self.redis_client = None
         self._connect()
     
     def _connect(self):
-        """Connect to Redis server."""
+        """Connect to Dragonfly server."""
         try:
-            self.redis_client = redis.from_url(self.redis_url, decode_responses=True)
+            self.redis_client = redis.from_url(self.dragonfly_url, decode_responses=True)
             # Test connection
             self.redis_client.ping()
-            logger.info("Successfully connected to Redis")
+            logger.info("Successfully connected to Dragonfly")
         except Exception as e:
-            logger.warning(f"Failed to connect to Redis: {e}. Cache operations will be disabled.")
+            logger.warning(f"Failed to connect to Dragonfly: {e}. Cache operations will be disabled.")
             self.redis_client = None
     
     def is_available(self) -> bool:
-        """Check if Redis is available."""
+        """Check if Dragonfly is available."""
         return self.redis_client is not None
     
     def set(self, key: str, value: Any, expire_seconds: int = None) -> bool:

--- a/src/services/daily_portfolio_tracker.py
+++ b/src/services/daily_portfolio_tracker.py
@@ -111,11 +111,11 @@ class DailyPortfolioTracker:
     # SQLite fallback removed
 
     def init_cache(self):
-        """Initialize Redis cache manager"""
+        """Initialize Dragonfly cache manager"""
         try:
-            from .redis_cache_manager import get_cache_manager
+            from .dragonfly_cache_manager import get_cache_manager
             self.cache_manager = get_cache_manager()
-            logger.info("Redis cache manager initialized for portfolio tracker")
+            logger.info("Dragonfly cache manager initialized for portfolio tracker")
         except Exception as e:
             logger.warning(f"Cache manager initialization failed: {e}")
             self.cache_manager = None

--- a/src/services/dragonfly_cache_manager.py
+++ b/src/services/dragonfly_cache_manager.py
@@ -1,7 +1,7 @@
 """
-Redis Cache Manager for Stock Experiment Application
+Dragonfly Cache Manager for Stock Experiment Application
 
-Provides centralized caching functionality using Redis for improved performance
+Provides centralized caching functionality using Dragonfly for improved performance
 and reduced database load.
 """
 
@@ -14,21 +14,21 @@ import pickle
 
 logger = logging.getLogger(__name__)
 
-class RedisCacheManager:
+class DragonflyCacheManager:
     """
-    Centralized Redis cache management for the Stock Experiment application.
+    Centralized Dragonfly cache management for the Stock Experiment application.
     Handles caching of portfolio data, market data, and performance metrics.
     """
 
-    def __init__(self, redis_url: str = None, host: str = 'localhost',
+    def __init__(self, dragonfly_url: str = None, host: str = 'localhost',
                  port: int = 6379, db: int = 0, password: str = None):
-        """Initialize Redis cache manager"""
+        """Initialize Dragonfly cache manager"""
         self.redis_client = None
         self.is_available = False
 
         try:
-            if redis_url:
-                self.redis_client = redis.from_url(redis_url, decode_responses=False)
+            if dragonfly_url:
+                self.redis_client = redis.from_url(dragonfly_url, decode_responses=False)
             else:
                 self.redis_client = redis.Redis(
                     host=host,
@@ -41,10 +41,10 @@ class RedisCacheManager:
             # Test connection
             self.redis_client.ping()
             self.is_available = True
-            logger.info("Redis cache manager initialized successfully")
+            logger.info("Dragonfly cache manager initialized successfully")
 
         except Exception as e:
-            logger.warning(f"Redis not available, cache disabled: {e}")
+            logger.warning(f"Dragonfly not available, cache disabled: {e}")
             self.redis_client = None
             self.is_available = False
 
@@ -65,7 +65,7 @@ class RedisCacheManager:
                 return pickle.loads(data)
             return None
         except Exception as e:
-            logger.warning(f"Redis get error for key {key}: {e}")
+            logger.warning(f"Dragonfly get error for key {key}: {e}")
             return None
 
     def set(self, key: str, value: Any, ttl: int = 300) -> bool:
@@ -78,7 +78,7 @@ class RedisCacheManager:
             self.redis_client.setex(key, ttl, serialized_data)
             return True
         except Exception as e:
-            logger.warning(f"Redis set error for key {key}: {e}")
+            logger.warning(f"Dragonfly set error for key {key}: {e}")
             return False
 
     def delete(self, key: str) -> bool:
@@ -90,7 +90,7 @@ class RedisCacheManager:
             self.redis_client.delete(key)
             return True
         except Exception as e:
-            logger.warning(f"Redis delete error for key {key}: {e}")
+            logger.warning(f"Dragonfly delete error for key {key}: {e}")
             return False
 
     def exists(self, key: str) -> bool:
@@ -101,7 +101,7 @@ class RedisCacheManager:
         try:
             return bool(self.redis_client.exists(key))
         except Exception as e:
-            logger.warning(f"Redis exists error for key {key}: {e}")
+            logger.warning(f"Dragonfly exists error for key {key}: {e}")
             return False
 
     # Portfolio-specific cache methods
@@ -226,20 +226,20 @@ class RedisCacheManager:
 # Singleton instance
 _cache_manager = None
 
-def get_cache_manager() -> RedisCacheManager:
+def get_cache_manager() -> DragonflyCacheManager:
     """Get the singleton cache manager instance"""
     global _cache_manager
     if _cache_manager is None:
         try:
             import config
-            _cache_manager = RedisCacheManager(
-                redis_url=config.REDIS_URL,
-                host=config.REDIS_HOST,
-                port=config.REDIS_PORT,
-                db=config.REDIS_DB,
-                password=config.REDIS_PASSWORD
+            _cache_manager = DragonflyCacheManager(
+                dragonfly_url=config.DRAGONFLY_URL,
+                host=config.DRAGONFLY_HOST,
+                port=config.DRAGONFLY_PORT,
+                db=config.DRAGONFLY_DB,
+                password=config.DRAGONFLY_PASSWORD
             )
         except ImportError:
             # Fallback if config not available
-            _cache_manager = RedisCacheManager()
+            _cache_manager = DragonflyCacheManager()
     return _cache_manager


### PR DESCRIPTION
Replaced the Redis caching service with Dragonfly.

- Updated `docker-compose.yml` and `docker-compose.dev.yml` to use the Dragonfly image.
- Renamed Redis configuration variables to Dragonfly in `config.py`.
- Updated `cache_service.py` to connect to Dragonfly.
- Renamed `redis_cache_manager.py` to `dragonfly_cache_manager.py` and updated it to use Dragonfly.
- Updated `daily_portfolio_tracker.py` to use the new dragonfly cache manager.

Note: The changes could not be verified due to an "out of disk space" error in the execution environment.